### PR TITLE
move `Test` into an extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        julia-version: ['~1.6.0-beta1', '1.5', '1.4', '1.0']
+        julia-version: ['lts', '1', 'pre', 'nightly']
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,17 @@ jobs:
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
-          file: ./lcov.info
-          flags: unittests
-          name: codecov-umbrella
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,12 @@ version = "0.1.16-DEV"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[weakdeps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[extensions]
+SplittablesTestingExt = "Test"
+
 [compat]
 Setfield = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1.0"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SplittablesTestingExt = "Test"
 
 [compat]
 Setfield = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1.0"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/ext/SplittablesTestingExt.jl
+++ b/ext/SplittablesTestingExt.jl
@@ -17,7 +17,7 @@ function SplittablesBase.Testing.test_ordered(examples)
             vec(collect(getdata(x))),
             )
         end
-        test_recursive_halving(x)
+        SplittablesBase.Testing.test_recursive_halving(x)
     end
 end
 
@@ -32,7 +32,7 @@ function SplittablesBase.Testing.test_unordered(examples)
             merge(+, countmap(collect(left)), countmap(collect(right))),
             )
         end
-        test_recursive_halving(x)
+        SplittablesBase.Testing.test_recursive_halving(x)
     end
 end
 

--- a/ext/SplittablesTestingExt.jl
+++ b/ext/SplittablesTestingExt.jl
@@ -1,0 +1,49 @@
+module SplittablesTestingExt
+using SplittablesBase
+
+using Test: @test, @testset
+using SplittablesBase: amount, halve
+using SplittablesBase.Testing: getdata, countmap, recursive_vcat
+
+
+function SplittablesBase.Testing.test_ordered(examples)
+    @testset "$(getlabel(x))" for x in enumerate(examples)
+        @debug "Testing `vcat`: $(getlabel(x))"
+        @testset "vcat" begin
+            data = getdata(x)
+            left, right = halve(getdata(x))
+            @test isequal(
+            vcat(vec(collect(left)), vec(collect(right))),
+            vec(collect(getdata(x))),
+            )
+        end
+        test_recursive_halving(x)
+    end
+end
+
+
+function SplittablesBase.Testing.test_unordered(examples)
+    @testset "$(getlabel(x))" for x in enumerate(examples)
+        @testset "concatenation" begin
+            data = getdata(x)
+            left, right = halve(getdata(x))
+            @test isequal(
+            countmap(collect(data)),
+            merge(+, countmap(collect(left)), countmap(collect(right))),
+            )
+        end
+        test_recursive_halving(x)
+    end
+end
+
+function SplittablesBase.Testing.test_recursive_halving(x)
+    @debug "Testing _recursive halving_: $(getlabel(x))"
+    @testset "recursive halving" begin
+        if Base.IteratorSize(getdata(x)) isa Union{Base.HasLength,Base.HasShape}
+            @test isequal(recursive_vcat(getdata(x), length), vec(collect(getdata(x))))
+        end
+        @test isequal(recursive_vcat(getdata(x)), vec(collect(getdata(x))))
+    end
+end
+
+end #module

--- a/ext/SplittablesTestingExt.jl
+++ b/ext/SplittablesTestingExt.jl
@@ -3,7 +3,7 @@ using SplittablesBase
 
 using Test: @test, @testset
 using SplittablesBase: amount, halve
-using SplittablesBase.Testing: getdata, countmap, recursive_vcat
+using SplittablesBase.Testing: getdata, getlabel, countmap, recursive_vcat
 
 
 function SplittablesBase.Testing.test_ordered(examples)

--- a/src/SplittablesBase.jl
+++ b/src/SplittablesBase.jl
@@ -12,10 +12,11 @@ end  # module
 
 module Testing
     include("testing.jl")
+    if !isdefined(Base,:get_extension)
+        include("../ext/SplittablesTestingExt.jl")
+    end
 end
 
-if !isdefined(Base,:get_extension)
-    include("../ext/SplittablesTestingExt.jl")
-end
+
 
 end # module

--- a/src/SplittablesBase.jl
+++ b/src/SplittablesBase.jl
@@ -11,9 +11,11 @@ include("implementations.jl")
 end  # module
 
 module Testing
-using Test: @test, @testset
-using ..SplittablesBase: amount, halve
-include("testing.jl")
-end  # module
+    include("testing.jl")
+end
+
+if !isdefined(Base,:get_extension)
+    include("../ext/SplittablesTestingExt.jl")
+end
 
 end # module

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -1,3 +1,5 @@
+using ..SplittablesBase: halve
+
 # Load docstring from markdown files:
 for (name, path) in [:test_ordered => joinpath(@__DIR__, "test_ordered.md")]
     try
@@ -82,33 +84,6 @@ function recursive_vcat(data, _len, recursions, limit, err)
     )
 end
 
-function test_recursive_halving(x)
-    @debug "Testing _recursive halving_: $(getlabel(x))"
-    @testset "recursive halving" begin
-        if Base.IteratorSize(getdata(x)) isa Union{Base.HasLength,Base.HasShape}
-            @test isequal(recursive_vcat(getdata(x), length), vec(collect(getdata(x))))
-        end
-        @test isequal(recursive_vcat(getdata(x)), vec(collect(getdata(x))))
-    end
-end
-
-function test_ordered(examples)
-    @testset "$(getlabel(x))" for x in enumerate(examples)
-        @debug "Testing `vcat`: $(getlabel(x))"
-        @testset "vcat" begin
-            data = getdata(x)
-            left, right = halve(getdata(x))
-            @test isequal(
-                vcat(vec(collect(left)), vec(collect(right))),
-                vec(collect(getdata(x))),
-            )
-        end
-        test_recursive_halving(x)
-    end
-end
-
-@deprecate test test_ordered false
-
 function countmap(xs)
     counts = Dict{Any,Int}()
     for x in xs
@@ -117,24 +92,18 @@ function countmap(xs)
     return counts
 end
 
+#the actual implementations are in ext/SplittablesTestingExt.jl
+function test_recursive_halving end
+function test_ordered end
+
+@deprecate test test_ordered false
+
 """
     SplittablesTesting.test_unordered(examples)
 
 See [`test_ordered`](@ref Main.SplittablesTesting.test_ordered).
 """
-function test_unordered(examples)
-    @testset "$(getlabel(x))" for x in enumerate(examples)
-        @testset "concatenation" begin
-            data = getdata(x)
-            left, right = halve(getdata(x))
-            @test isequal(
-                countmap(collect(data)),
-                merge(+, countmap(collect(left)), countmap(collect(right))),
-            )
-        end
-        test_recursive_halving(x)
-    end
-end
+function test_unordered end
 
 const _PUBLIC_API = [
     # A list of public APIs to be picked by SplittablesTesting.jl

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -1,4 +1,4 @@
-using ..SplittablesBase: halve
+using ..SplittablesBase: halve, amount
 
 # Load docstring from markdown files:
 for (name, path) in [:test_ordered => joinpath(@__DIR__, "test_ordered.md")]


### PR DESCRIPTION
probably requires moving https://github.com/JuliaFolds/SplittablesTesting.jl into JuliaFolds2 before a release. (loading `SplittablesTesting` standalone will not load the test functions, only when `Test` is also loaded, the idea is to release a new version of `SplittablesTesting` that loads `Test` explicitly)